### PR TITLE
Remove unnecessary `raise`

### DIFF
--- a/ssrf_filter.gemspec
+++ b/ssrf_filter.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rspec', '~> 3.8.0')
   gem.add_development_dependency('webmock', '~> 3.5.1')
 
-  raise 'Unsupported version of ruby' unless major == 2
-
   if minor > 1
     gem.add_development_dependency('rubocop', '~> 0.65.0')
   elsif minor == 1


### PR DESCRIPTION
This gemspec already has a "required_ruby_version" of ">= 2" which seems sufficient, and avoids encountering an error if you happen to try installing this under ruby 3.